### PR TITLE
exec of rndc reload fails

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -115,7 +115,7 @@ define bind::zone (
         }
 
         if $zone_file_mode == 'managed' {
-            exec { "rndc reload ${_domain}":
+            exec { "rndc reload ${name}":
                 command     => "/usr/sbin/rndc reload ${_domain}",
                 user        => $bind_user,
                 refreshonly => true,


### PR DESCRIPTION
If a domain is in 2 or more views the rndc exec fails because it has a duplicate name.
