### PR TITLE
rndc reload now takes account of the zones views

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -116,11 +116,20 @@ define bind::zone (
 
         if $zone_file_mode == 'managed' {
             exec { "rndc reload ${name}":
-                command     => "/usr/sbin/rndc reload ${_domain}",
+                command     => "/bin/grep \"; Zone dump of '${_domain}\" ${cachedir}/named_dump.db | while read -r line; do VIEW=`echo \"\$line\" | /usr/bin/awk -F \"/\" '{ print substr(\$NF,1,length(\$NF)-1) }'`; /usr/sbin/rndc reload \"${_domain}\" IN \"\$VIEW\"; done",
                 user        => $bind_user,
                 refreshonly => true,
                 require     => Service['bind'],
                 subscribe   => File["${cachedir}/${name}/${zone_file}"],
+            }
+            
+            exec{"rndc-dump-zones ${name}":
+                command => '/usr/sbin/rndc dumpdb -zones',
+                user  => $bind_user,
+                refreshonly => true,
+                require    => Service['bind'],
+                subscribe  => File ["${::bind::confdir}/zones/${name}.conf"],
+                before     => Exec["rndc reload ${name}"],
             }
         }
     } elsif $zone_file_mode == 'absent' {


### PR DESCRIPTION
Uses an rndc dump of all zones to work out what zones this view is in to they can be correctly reloaded.
